### PR TITLE
Add destructor for file-pointers

### DIFF
--- a/modules/cstdio.dt
+++ b/modules/cstdio.dt
@@ -88,6 +88,8 @@ The standard error handle.
 (def fclose
   (fn extern-c int ((stream (p file)))))
 
+(def destroy (fn extern void ((val (ref (p file))))
+  (fclose (@ file))))
 #|
 @fn remove
 |#

--- a/modules/cstdio.dt
+++ b/modules/cstdio.dt
@@ -88,8 +88,8 @@ The standard error handle.
 (def fclose
   (fn extern-c int ((stream (p file)))))
 
-(def destroy (fn extern void ((val (ref (p file))))
-  (fclose (@ file))))
+(def destroy (fn extern void ((fref (ref (p file))))
+  (fclose (@ fref))))
 #|
 @fn remove
 |#


### PR DESCRIPTION
(not tested)
Why not implemented yet?
Or is some module stdio.dt planned, which should be used instead?

