### PR TITLE
Made `and` and `or` right-associative

### DIFF
--- a/modules/operator-macros.dt
+++ b/modules/operator-macros.dt
@@ -69,7 +69,10 @@ Defines a macro:
 (def def-left-associative-macro (macro extern (name linkage)
   (qq std.macros.def-left-associative-macro (uq name) (uq linkage) (uq name))))))
 
+(mfor op (and or)
+  (std.macros.def-right-associative-macro op extern))
+
 (mfor op (+  -  *  /
           +' -' *' /'
-          &  | and or)
+          &  |)
   (std.macros.def-left-associative-macro op extern))


### PR DESCRIPTION
May reduce the creation of temporary variables, when defining versions for them, that can take and return non-boolean values