### PR TITLE
added new version of  `and` and `or`

### DIFF
--- a/modules/stdlib.dt
+++ b/modules/stdlib.dt
@@ -710,6 +710,43 @@ Expands to the argument form.
   (macro extern (frm)
     frm))
 
+
+#|
+@macro and
+
+Returns the first argument, if it is not valid. Returns the last argument otherwise.
+A object `o` is valid if `(is-valid o)` returns true.
+
+
+@param condition    The condition expression.
+@param true-case    The form to run when condition is true.
+|#
+
+(def and (macro extern (a b)
+  (if (is-lvalue mc a)
+    (bqq if (not (is-valid (uq a))) (uq a) (uq b))
+    (let ((tmp \ (make-gensym-var-node mc)))
+      (bqq let (((uq tmp) \ (uq a)))
+        (if (not (is-valid (uq tmp))) (uq tmp) (uq b)))))))
+
+#|
+@macro or
+
+Returns the first argument, if it is valid. Returns the last argument otherwise.
+A object `o` is valid if `(is-valid o)` returns true.
+
+@param condition    The condition expression.
+@param false-case   The form to run when condition is false.
+|#
+
+(def or (macro extern (a b)
+  (if (is-lvalue mc a)
+    (bqq if (is-valid (uq a)) (uq a) (uq b))
+    (let ((tmp \ (make-gensym-var-node mc)))
+      (bqq let (((uq tmp) \ (uq a)))
+        (if (is-valid (uq tmp)) (uq tmp) (uq b)))))))
+
+
 #|
 @macro +'
 


### PR DESCRIPTION
Here some code to test if `or` works correctly
This Testcode doesn't work if operator-macros are defined after the new version of or is defined, until the overloading-resolutionproblem is fixed.
```
(import operator-macros)

(def object (struct intern ((value int))))

(def make-object (fn intern (p object) ((num int))
  (def object (var intern object ((value 0))))
  (printf "Trying to create object %i\n" num) ;;check if only evaluated once
  (if (= num 0) (# object)
                (nullptr object)))) ;;object not yet defined for 

(def main (fn extern-c void (void)
  (let ((is-valid \ (fn bool ((a (p object)))
                      (not (null a)))))
    (let ((object1 \ (make-object -1))
          (object2 \ (make-object 0))
          (object3 \ (make-object 1))
          (first-valid-object \ (or object1 object2 object3))
          (no-valid-object \ (or (make-object -5) (make-object 12) (make-object 3))))
      (printf
        (if (not (null first-valid-object)) "Some valid object has been created\n"
                                            "No valid object has been created\n"))
      (printf
        (if (not (null no-valid-object)) "Some valid object has been created\n"
                                         "No valid object has been created\n"))))))
```

The existing versions of and and or may be replaced by defining is-valid for bool as a identity macro.
(But this only should be done, if overload-selection is faster, when only a single macro exists, else it may be slower then)