### PR TITLE
impc added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ standard_library (modules/derivations.dt derivations   utility)
 standard_library (modules/enum.dt        enum          utility)
 standard_library (modules/bitset-enum.dt bitset-enum   enum)
 standard_library (modules/variant.dt     variant       enum)
+standard_library (modules/impc.dt     impc       macros)
 
 set_directory_properties (PROPERTIES 
                           ADDITIONAL_MAKE_CLEAN_FILES

--- a/modules/impc.dt
+++ b/modules/impc.dt
@@ -1,0 +1,71 @@
+#|
+@module impc
+
+Provides macros for easier importing extern-c functions. All of the bindings
+provided by this library are in the std namespace.
+
+|#
+(module impc (attr cto))
+
+(import macros)
+
+
+(namespece std ;;namespace may be different
+(using-namespace std.macros
+
+#|
+@macro std.defc
+
+Defines an extern-c function and a function, which calls the extern-c function.
+
+@example
+(defc func extern libFunc void ((a int) (b int)))
+
+
+@param name The function name.
+@param linkage Linkage of the function.
+@param cname The name of the c function.
+@param type The return type of the functions.
+@param args The arglist of the functions.
+
+
+@linkage extern
+|#
+(def defc (macro extern (name linkage cname type args)
+  (let ((arg-list \ (arg-list-names mc args))
+        (fdef \ (if (null arg-list) (qq (uq cname))
+                                    (qq (uq cname) (uql-nc arg-list)))))
+    (qq do
+      ;;may be useful, if the extern-c functions would be defined in another namespace for extern-c functions
+      (def (uq cname) (fn extern-c (uq type) (uq args)))
+      (def (uq name) (fn (uq linkage) (uq type) (uq args)
+        (uq fdef)))))))
+
+#|
+@macro std.defc-multi
+
+Similar to defc, but can define an overloaded version of c functions.
+
+@example
+(defc-multi func extern
+  (libFunc1i void ((a int)))
+  (libFunc2i void ((a int) (b int)))
+  (libFunc1f void ((a float)))
+  (libFunc2f void ((a float) (b float))))
+
+
+@linkage extern
+|#
+(def defc-multi (macro extern (name linkage def0 rest)
+  (def list (var auto \ (get-varargs-list mc (- (arg-count mc) 3) rest)))
+  (ignore assert (not (= 0 (@:@ def0 is-list))))
+  (def defc (var auto \ (qq defc (uq name) (uq linkage) (uql (@:@ def0 list-node)))))
+  (if (null list)
+    defc
+    (qq do
+      (uq defc)
+      (defc-multi (uq name) (uq linkage) (uql list))))))
+
+))
+
+

--- a/modules/macros.dt
+++ b/modules/macros.dt
@@ -1482,4 +1482,56 @@ nodes are supported.
           ;(DNode-print res)
           ;(printf "\n")
           res))
+
+#|
+@fn std.macros.apply-list
+
+Similar to `walk-nodes`. Calls function `fn` on all nodes of the list, and returns a new list, containing the return values of the lists.
+
+@param mc An MContext.
+@param form     The first node of a list.
+@param data     Arbitrary data.
+@param fn       The function pointer to call on each node.
+|#
+(def apply-list
+  (fn (attr cto) extern (p DNode)
+      ((mc (p MContext))
+       (list (p DNode))
+       (data (p void))
+       (fun (p (fn (p DNode) ((mc (p MContext))
+                              (node (p DNode))
+                              (data (p void)))))))
+    (def elt (var auto \ (fun mc list data)))
+    (if (not (null (@:@ list next-node)))
+      (new-scope (def rest (var auto \ (@:@ (apply-list mc (@:@ list next-node) data fun) list-node)))
+                 (qq (uq elt) (uql rest)))
+      (qq (uq elt)))))
+
+;;following may be added to an extra module containing functions for parsing names, types, etc.
+#|
+@fn std.macros.arg-list-names
+
+Returns the names of the argument list.
+
+@param mc An MContext.
+@param form     An argument list.
+|#
+(def arg-list-names (fn (attr cto) extern (p DNode) ((mc (p MContext)) (form (p DNode)))
+  (and (not (= 0 (@:@ form is-list)))
+    (and (= 0 (@:' form list-node is-list))
+      (and (= 0 (strncmp (@:' form list-node token-str) "void" (cast 4 size)))
+        ;; (= (@:' form list-node) (q void))
+        (return (nullptr DNode)))))
+  (let ((list \
+         (apply-list mc (@:@ form list-node) (nullptr void)
+           (fn (attr cto) (p DNode) ((mc (p MContext)) (form (p DNode)) (data (p void)))
+             (if (= 0 (@:@ form is-list))
+               form
+               (@:@ form list-node))))))
+    (@:@ list list-node))))
+
+))
+
+
+
 ))


### PR DESCRIPTION
defc and defc-multi simplifies defining of c functions (you don't have to define them twice, like in mawled, I changed mawled to use these macros. I will also send a pull request, it currently implements the macros and functions itself)