### PR TITLE
Autowrap

### DIFF
--- a/eg/dale-autowrap/c2dale.sh
+++ b/eg/dale-autowrap/c2dale.sh
@@ -1,0 +1,5 @@
+for a in $@
+do
+  c2ffi $INCLUDE_PATH/$a.h | ./dale-autowrap.pl $a > $a.dt
+done
+

--- a/eg/dale-autowrap/dale-autowrap.pl
+++ b/eg/dale-autowrap/dale-autowrap.pl
@@ -15,6 +15,16 @@ my %TYPE_MAP = (
     'unsigned-long'      => '(ulong-type)',
     'long-long'          => '(long-long-type)',
     'unsigned-long-long' => '(ulong-long-type)',
+    'ptrdiff_t'          => 'ptrdiff',
+    'uint8_t'            => 'uint8',
+    'uint16_t'           => 'uint16',
+    'uint32_t'           => 'uint32',
+    'uint64_t'           => 'uint64',
+    'int8_t'             => 'int8',
+    'int16_t'            => 'int16',
+    'int32_t'            => 'int32',
+    'int64_t'            => 'int64',
+    
 );
 
 sub type_to_string

--- a/eg/dale-autowrap/dale-autowrap.pl
+++ b/eg/dale-autowrap/dale-autowrap.pl
@@ -8,6 +8,7 @@ use JSON::XS qw(decode_json);
 my %TYPEMAP = (
     'unsigned-int'       => 'uint',
     'unsigned-char'      => 'uint8',
+    'signed-char'        => 'int8',
     'short'              => '(short-type)',
     'unsigned-short'     => '(ushort-type)',
     'long'               => '(long-type)',
@@ -120,6 +121,15 @@ sub process_enum
             $field_str);
 }
 
+sub process_typedef
+{
+    my ($data) = @_;
+
+    sprintf("(def %s (struct extern ((a %s))))",
+            $data->{'name'},
+            type_to_string($data->{'type'}));
+}
+
 sub main
 {
     print "(import stdlib)\n";
@@ -149,6 +159,9 @@ sub main
             print "$str\n";
         } elsif ($tag eq 'enum') {
             my $str = process_enum($data);
+            print "$str\n";
+        } elsif ($tag eq 'typedef') {
+            my $str = process_typedef($data);
             print "$str\n";
         }
     }

--- a/eg/dale-autowrap/dale-autowrap.pl
+++ b/eg/dale-autowrap/dale-autowrap.pl
@@ -169,9 +169,12 @@ sub process_typedef
 {
     my ($data, $imports) = @_;
     
-    sprintf("(def %s (struct extern ((a %s))))",
-            $data->{'name'},
-            $type);
+    my $type = type_to_string($data->{'type'}, $imports);
+    if (not ($type eq 'void')) {
+      sprintf("(def %s (struct extern ((a %s))))",
+              $data->{'name'},
+              $type);
+    }
 }
 
 sub process_union

--- a/eg/dale-autowrap/dale-autowrap.pl
+++ b/eg/dale-autowrap/dale-autowrap.pl
@@ -1,8 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/perl -w
 
 use warnings;
 use strict;
-
+use File::Basename;
 use JSON::XS qw(decode_json);
 
 my %TYPEMAP = (
@@ -134,7 +134,7 @@ sub main
 {
     print "(import stdlib)\n";
 
-    while (defined (my $entry = <>)) {
+    while (defined (my $entry = <STDIN>)) {
         chomp $entry;
         if ($entry eq '[') {
             next;
@@ -144,6 +144,14 @@ sub main
         }
         $entry =~ s/,\s*$//;
         my $data = decode_json($entry);
+        if($#ARGV>=0) {
+          my $path = $data->{'location'};
+          my $name = fileparse($path,qr/\.[^.]*/);  
+          my $arg = $ARGV[0];
+          if(not ($name eq $arg)) {
+            next;
+          }
+        }
         my $tag = $data->{'tag'};
         if ($tag eq 'function') {
             my $str = process_function($data);


### PR DESCRIPTION
if you specify a name to dale-autowrap.pl (the filename without extension), it will only handle everything defined in that file
also added an example usage in the same directory (c2dale.sh)
usage: 
```
$ export INCLUDE_PATH=/usr/include/GL #the directory where the included files are
$ ./c2dale.sh gl glut freeglut freeglut_std freeglut_ext #etc.
```
(includes still have to specified oneself, it may be possible to add support to this to the perl-program by not just "next;" when wrong filename but also adding `(include "wrong-filename.dt")` (problem: everything has to included only once, even if in different files / other problem: some files should not be included anyway (like c's `stdlib.h` or similar)
