### PR TITLE
use voidpointer for function pointers

### DIFF
--- a/eg/dale-autowrap/dale-autowrap.pl
+++ b/eg/dale-autowrap/dale-autowrap.pl
@@ -45,6 +45,9 @@ sub type_to_string
     if ($tag eq 'union') {
         return $type->{'name'};
     }
+    if ($tag eq 'function-pointer') {
+        return "(p void)"
+    }
 
     my $mapped_type = $TYPE_MAP{$tag};
     if ($mapped_type) {


### PR DESCRIPTION
It seems that c2ffi doesn't save function-pointer signatures. I changed this to a void pointer in code (which isnt the correct type, but it works without changing the generated code, using casts)
I also reported this as issue, the correct fp-signatures by default are beneficial.
Maybe it would also be useful, if the default type is a function type (maybe `(p (fn void (void)))`)
