### PR TITLE
A cleanup of the buffers in `main`

### DIFF
--- a/src/dale/dalec.cpp
+++ b/src/dale/dalec.cpp
@@ -20,6 +20,7 @@ using namespace dale;
 
 static const char *options = "M:m:O:a:I:L:l:o:s:b:cdrR";
 static const size_t COPY_SIZE = 8192;
+static const int MAX_COMPILE_COMMAND_LENGTH = 8192;  /* buffer size */
 
 static bool
 appearsToBeLib(const char *str)
@@ -348,10 +349,10 @@ main(int argc, char **argv)
         exit(0);
     }
 
-    char compile_cmd[8192];
+    char compile_cmd[MAX_COMPILE_COMMAND_LENGTH];
     int bytes = 0;
     if (no_linking) {
-        bytes = snprintf(compile_cmd, (8192 - 1),
+        bytes = snprintf(compile_cmd, MAX_COMPILE_COMMAND_LENGTH - 1,
                          DALE_CC "%s -c %s %s %s %s -o %s",
                          (no_stdlib) ? "--nostdlib" : "",
                          run_path_str.c_str(),
@@ -360,7 +361,7 @@ main(int argc, char **argv)
                          intermediate_output_path.c_str(),
                          output_path.c_str());
     } else {
-        bytes = snprintf(compile_cmd, (8192 - 1),
+        bytes = snprintf(compile_cmd, MAX_COMPILE_COMMAND_LENGTH - 1,
                          DALE_CC "%s %s %s %s %s %s %s -lm -o %s",
                          (no_stdlib) ? "--nostdlib" : "",
                          (strcmp(SYSTEM_NAME, "Darwin")
@@ -373,7 +374,7 @@ main(int argc, char **argv)
                          run_lib_str.c_str(),
                          output_path.c_str());
     }
-    if (bytes >= 8192) {
+    if (bytes >= MAX_COMPILE_COMMAND_LENGTH) {
         error(DALE_CC " command is too long");
     }
 

--- a/src/dale/dalec.cpp
+++ b/src/dale/dalec.cpp
@@ -57,7 +57,7 @@ copyFile(const char *to_path, FILE *from)
     if (!to) {
         error("unable to open %s for writing", to_path, true);
     }
-    char buf[COPY_SIZE];
+    static char buf[COPY_SIZE];  /* on heap, not stack */
     memset(buf, 0, COPY_SIZE);
     size_t bytes;
     size_t wbytes;
@@ -349,7 +349,7 @@ main(int argc, char **argv)
         exit(0);
     }
 
-    char compile_cmd[MAX_COMPILE_COMMAND_LENGTH];
+    static char compile_cmd[MAX_COMPILE_COMMAND_LENGTH];  /* on heap */
     int bytes = 0;
     if (no_linking) {
         bytes = snprintf(compile_cmd, MAX_COMPILE_COMMAND_LENGTH - 1,


### PR DESCRIPTION
- eliminate some "magic numbers"
- do not use the stack for the buffers