### PR TITLE
remove platform dependent use of 'sed' for getting major and minor llvm versions. using cmake regex instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,16 +27,10 @@ execute_process (COMMAND ${LLVM_CONFIG} --version
 execute_process (COMMAND ${LLVM_CONFIG} --bindir
                  OUTPUT_VARIABLE LLVM_BIN_DIR
                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process (COMMAND echo ${D_LLVM_VERSION}
-                 COMMAND sed -e "s/[^0-9].*//"
-                 OUTPUT_VARIABLE D_LLVM_VERSION_MAJOR
-                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process (COMMAND echo ${D_LLVM_VERSION}
-                 COMMAND sed -e "s/[0-9]*\\.//"
-                 COMMAND sed -e "s/svn//"
-                 COMMAND sed -e "s/\\..*//"
-                 OUTPUT_VARIABLE D_LLVM_VERSION_MINOR
-                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+string(REGEX MATCH "[^0-9]*([^.]+)\.([^.]+).*" _ ${D_LLVM_VERSION})
+set(D_LLVM_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(D_LLVM_VERSION_MINOR ${CMAKE_MATCH_2})
 
 if (NOT D_LLVM_VERSION)
     message (FATAL_ERROR "Unable to retrieve version number from llvm-config executable (${LLVM_CONFIG})")


### PR DESCRIPTION
powershell
```
PS C:\Users\me\notMyCode\tomhrr\dale.build.developer-powershell-for-vs> cmake -DLLVM_CONFIG="C:\Users\me\Downloads\llvm\llvm-project-14.0.6.src\build\Release\bin\llvm-config.exe" ..\dale\
-- Building for: Visual Studio 16 2019
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.22631.
-- The C compiler identification is MSVC 19.29.30152.0
-- The CXX compiler identification is MSVC 19.29.30152.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
fatal: not a git repository (or any of the parent directories): .git
-- LLVM version: 14.0.6
-- LLVM version major: 14
-- LLVM version minor: 0
-- System name: Windows
-- System processor: AMD64
-- System version: 10.0.22631
-- Found PkgConfig: C:/Program Files/Git/mingw64/bin/pkg-config.exe (found version "2.0.3")
-- Checking for one of the modules 'libffi'
-- Build type: RELEASE
-- Configuring done (3.4s)
-- Generating done (0.3s)
-- Build files have been written to: C:/Users/me/notMyCode/tomhrr/dale.build.developer-powershell-for-vs
```
msys2
```
$ cmake ../dale -DLLVM_CONFIG="/c/git-sdk-64/mingw64/opt/llvm-14/bin/llvm-config.exe"
fatal: not a git repository (or any of the parent directories): .git
-- LLVM version: 14.0.6
-- LLVM version major: 14
-- LLVM version minor: 0
-- System name: MSYS
-- System processor: x86_64
-- System version: 3.4.9-be826601.x86_64
-- Found PkgConfig: /usr/bin/pkg-config.exe (found version "1.7.4")
-- Checking for one of the modules 'libffi'
-- Build type: RELEASE
-- Configuring done (1.3s)
-- Generating done (0.8s)
-- Build files have been written to: /c/Users/me/notMyCode/tomhrr/dale.build
```